### PR TITLE
Master Hand selectable as LINK variant behind a toggle

### DIFF
--- a/src/CharacterSelect.asm
+++ b/src/CharacterSelect.asm
@@ -600,11 +600,11 @@ scope CharacterSelect {
         bnel    t0, t1, _end                // If not BOSS, return variant ID
         addu    v0, r0, t1                  // v0 = variant ID
 
-        li      t0, CharacterSelectDebugMenu.PlayerTag.string_table + (20 * 4)
-        lw      t0, 0x0000(t0)              // t0 = 20th tag
-        lbu     t0, 0x0000(t0)              // t0 = first character
-        bnezl   t0, _end                    // if not blank, return variant ID
-        addu    v0, r0, t1                  // v0 = variant ID
+        // BOSS (Master Hand) is gated behind the "Master Hand (LINK variant)"
+        // toggle so casual matches don't accidentally expose it on the CSS.
+        Toggles.read(entry_master_hand_link, t0)
+        bnezl   t0, _end                    // toggle ON → return variant ID
+        addu    v0, r0, t1                  // v0 = variant ID (delay slot)
 
         _end:
         lw      t0, 0x0004(sp)              // ~
@@ -1289,10 +1289,10 @@ scope CharacterSelect {
         bnel    a0, v0, _check_recent_randoms // valid variant if not Master Hand
         addu    v0, r0, a0                    // v0 = character id (variant)
 
-        li      v1, CharacterSelectDebugMenu.PlayerTag.string_table + (20 * 4)
-        lw      v1, 0x0000(v1)              // v1 = 20th tag
-        lbu     v1, 0x0000(v1)              // v1 = first character
-        beqzl   v1, _check_recent_randoms   // if blank, not a valid variant
+        // BOSS only counts as a valid variant when the toggle is enabled —
+        // otherwise fall through to "use original character".
+        Toggles.read(entry_master_hand_link, v1)
+        beqzl   v1, _check_recent_randoms   // toggle OFF → not a valid variant
         srl     v0, s0, 0x0002              // v0 = character id (not a variant)
 
         addu    v0, r0, a0                  // v0 = character id (variant)
@@ -5181,10 +5181,10 @@ scope CharacterSelect {
         bne     a1, t2, _gdk                // If not Master Hand, then skip... otherwise, draw Master Hand stock icon
         addiu   a1, at, VARIANT_ICON_OFFSET.MASTER_HAND // a1 = Master Hand footer struct
 
-        li      t1, CharacterSelectDebugMenu.PlayerTag.string_table + (20 * 4)
-        lw      t1, 0x0000(t1)              // t1 = 20th tag
-        lbu     t1, 0x0000(t1)              // t1 = first character
-        beqz    t1, _end                    // if blank, skip
+        // Stock-icon draw is also gated by the Master Hand toggle so an
+        // accidentally-cached BOSS variant doesn't leak into the HUD.
+        Toggles.read(entry_master_hand_link, t1)
+        beqz    t1, _end                    // toggle OFF → skip drawing the icon
         nop
         b       _draw_icon
         nop

--- a/src/Toggles.asm
+++ b/src/Toggles.asm
@@ -2407,7 +2407,8 @@ scope Toggles {
     entry_pk_thunder_reflect_crash_fix:;entry_bool("PK Thunder Reflect Crash Fix", OS.TRUE, OS.TRUE, OS.TRUE, OS.TRUE, entry_flash_guard)
     entry_flash_guard:;                 entry_bool("Flash Guard", OS.FALSE, OS.FALSE, OS.FALSE, OS.FALSE, entry_screenshake)
     entry_screenshake:;                 entry("Screenshake", Menu.type.INT, OS.FALSE, OS.FALSE, OS.FALSE, OS.FALSE, 0, 2, OS.NULL, string_table_screenshake, OS.NULL, entry_blastzone_gfx)
-    entry_blastzone_gfx:;               entry("BlastZone GFX", Menu.type.INT, 0, 0, 0, 0, 0, 2, OS.NULL, string_table_blastzone_gfx, OS.NULL, OS.NULL)
+    entry_blastzone_gfx:;               entry("BlastZone GFX", Menu.type.INT, 0, 0, 0, 0, 0, 2, OS.NULL, string_table_blastzone_gfx, OS.NULL, entry_master_hand_link)
+    entry_master_hand_link:;            entry_bool("Master Hand (LINK variant)", OS.FALSE, OS.FALSE, OS.FALSE, OS.FALSE, OS.NULL)
 
     evaluate num_remix_toggles(num_toggles)
     evaluate remix_toggles_block_size(block_size)


### PR DESCRIPTION

<img width="318" height="239" alt="Screenshot2" src="https://github.com/user-attachments/assets/17ecd05c-d3ea-403d-be07-f1c212b426c9" />
<img width="321" height="239" alt="Screenshot3" src="https://github.com/user-attachments/assets/859c0ffa-a133-4bce-bddd-4b9b321a1efe" />


Replaces the hidden 'PlayerTag 20 must be non-blank' gating at three spots in CharacterSelect.asm with a proper Gameplay toggle:

  Toggles → 'Master Hand (LINK variant)'  (default: OFF)

When the toggle is ON, hovering LINK on the CSS and pressing the variant button (D-pad) cycles through Link's variants AND surfaces BOSS (Master Hand) as the last entry. Stock icon, name texture, menu-zoom etc. are already wired up because the variant slot was always defined — only the user-facing gate changes here.

The three affected paths:
- get_character_id_         : hover → returned char id
- variant validity filter   : random/cursor variant lookup
- draw_variant_icon_        : HUD stock-icon draw

All three now do a Toggles.read of entry_master_hand_link instead of probing the PlayerTag string table, which made the feature only discoverable to people who happened to know that tag 20 was a debug-only sentinel.